### PR TITLE
feat(webhook): adds webhook that handles fetching annotations from external integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+services:
+  - redis
 node_js:
   - "0.10"
   - "0.12"

--- a/lib/client-manager.js
+++ b/lib/client-manager.js
@@ -2,7 +2,7 @@ var _ = require('lodash')
 var crypto = require('crypto')
 var request = require('request')
 var redis = require('redis')
-// var map = require('async').map
+var map = require('async').map
 
 function ClientManager (opts) {
   _.assign(this, {
@@ -17,6 +17,9 @@ function ClientManager (opts) {
   this.client = redis.createClient(this.redisUrl)
 }
 
+// loads clients from our OAuth micro-service.
+// these clients each represent a single integration
+// (as an example, Lift.)
 ClientManager.prototype.load = function (loaded) {
   var _this = this
   request.get({
@@ -35,7 +38,8 @@ ClientManager.prototype.load = function (loaded) {
   })
 }
 
-// dispatch a signed package event to the external clients.
+// fetch annotations from external services, returning
+// from cache if possible:
 // {
 //  "event": "package:page-load",
 //  "package": "left-pad",
@@ -44,24 +48,66 @@ ClientManager.prototype.load = function (loaded) {
 //  }
 // }
 ClientManager.prototype.annotationsForPageLoad = function (pkgName, cb) {
+  var _this = this
   this.client.lrange(this.key(pkgName), 0, 9999, function (err, annotations) {
-    if (err) {
-      console.error(err.message)
-    }
-    if (annotations) {
+    if (err) console.error(err.message)
+    if (annotations && annotations.length) {
       return cb(annotations.map(function (annotation) {
         return JSON.parse(annotation)
       }))
     } else {
-
+      _this.fetchAnnotations(pkgName, function (annotations) {
+        _this.cacheAnnotations(pkgName, annotations, function () {
+          return cb(annotations)
+        })
+      })
     }
+  })
+}
+
+// fetch annotations from all the external integrations.
+ClientManager.prototype.fetchAnnotations = function (pkgName, cb) {
+  var _this = this
+  map(this.clients, function (client, done) {
+    var payload = JSON.stringify({
+      event: 'package:page-load',
+      package: pkgName,
+      sender: {
+        email: client.tokens[0].user_email
+      }
+    })
+    var signature = _this.sign(payload, client)
+
+    request.post({
+      url: client.callback,
+      body: payload,
+      headers: {
+        'content-type': 'application/json',
+        'npm-signature': signature
+      }
+    }, function (err, res, body) {
+      if (res.statusCode >= 400) {
+        err = Error('unexpected status code = ' + res.statusCode)
+      }
+      if (err) console.error(err.message)
+      if (body) {
+        body = JSON.parse(body)
+        // the integration id is used to de-dupe.
+        // the UI on the frontend.
+        body.id = client.client_id
+      }
+      return done(null, body)
+    })
+  }, function (_err, annotations) {
+    return cb(annotations.filter(function (item) {
+      return !!item
+    }))
   })
 }
 
 /*
 Cache a set of annotations, so we don't hammer
 the external API:
-
 [{
   id: 'abc-123-abc',
   status: 'green',
@@ -73,7 +119,7 @@ the external API:
 */
 ClientManager.prototype.cacheAnnotations = function (pkgName, annotations, cb) {
   // toss a fingerprint on our annotation so that the
-  // frontend can dedupe, and turn it into a string for Redis.
+  // frontend can dedupe and turn it into a string for Redis.
   annotations = annotations.map(function (annotation) {
     annotation.fingerprint = hash(JSON.stringify(annotation), '')
     return JSON.stringify(annotation)
@@ -87,6 +133,7 @@ ClientManager.prototype.cacheAnnotations = function (pkgName, annotations, cb) {
   })
 }
 
+// helpers for signing the webhook payload.
 ClientManager.prototype.sign = function (payload, client) {
   var secret = client.tokens[0].access_token
   return 'sha256=' + hash(payload, secret)

--- a/lib/client-manager.js
+++ b/lib/client-manager.js
@@ -133,20 +133,19 @@ ClientManager.prototype.cacheAnnotations = function (pkgName, annotations, cb) {
   })
 }
 
+function hash (payload, secret) {
+  return crypto.createHmac('sha256', secret)
+    .update(payload)
+    .digest('hex')
+}
+
 // helpers for signing the webhook payload.
 ClientManager.prototype.sign = function (payload, client) {
   var secret = client.tokens[0].access_token
   return 'sha256=' + hash(payload, secret)
 }
-
 ClientManager.prototype.key = function (pkgName) {
   return this.redisPrefix + pkgName
-}
-
-function hash (payload, secret) {
-  return crypto.createHmac('sha256', secret)
-    .update(payload)
-    .digest('hex')
 }
 
 module.exports = ClientManager

--- a/lib/client-manager.js
+++ b/lib/client-manager.js
@@ -1,5 +1,105 @@
-function ClientManager (opts) {
+var _ = require('lodash')
+var crypto = require('crypto')
+var request = require('request')
+var redis = require('redis')
+// var map = require('async').map
 
+function ClientManager (opts) {
+  _.assign(this, {
+    clients: [],
+    oauthUrl: 'http://0.0.0.0:8084/client',
+    redisUrl: 'redis://0.0.0.0:6379',
+    redisPrefix: '__anotation_api_',
+    // only make requests to external sites every 15 seconds.
+    ttl: 15
+  }, opts)
+
+  this.client = redis.createClient(this.redisUrl)
+}
+
+ClientManager.prototype.load = function (loaded) {
+  var _this = this
+  request.get({
+    url: this.oauthUrl,
+    json: true
+  }, function (err, res, body) {
+    if (res.statusCode !== 200) {
+      err = Error('unexpected status code = ' + res.statusCode)
+    }
+    if (err) {
+      return loaded(err)
+    } else {
+      _this.clients.push.apply(_this.clients, body)
+      return loaded()
+    }
+  })
+}
+
+// dispatch a signed package event to the external clients.
+// {
+//  "event": "package:page-load",
+//  "package": "left-pad",
+//  "sender": {
+//    "email": "ben@example.com"
+//  }
+// }
+ClientManager.prototype.annotationsForPageLoad = function (pkgName, cb) {
+  this.client.lrange(this.key(pkgName), 0, 9999, function (err, annotations) {
+    if (err) {
+      console.error(err.message)
+    }
+    if (annotations) {
+      return cb(annotations.map(function (annotation) {
+        return JSON.parse(annotation)
+      }))
+    } else {
+
+    }
+  })
+}
+
+/*
+Cache a set of annotations, so we don't hammer
+the external API:
+
+[{
+  id: 'abc-123-abc',
+  status: 'green',
+  'status-message': 'module scanned',
+  description: 'my awesome integration',
+  'external-link': 'http://example.com/foo-package/audit',
+  'external-link-text': 'view details'
+}]
+*/
+ClientManager.prototype.cacheAnnotations = function (pkgName, annotations, cb) {
+  // toss a fingerprint on our annotation so that the
+  // frontend can dedupe, and turn it into a string for Redis.
+  annotations = annotations.map(function (annotation) {
+    annotation.fingerprint = hash(JSON.stringify(annotation), '')
+    return JSON.stringify(annotation)
+  })
+  this.client.lpush(this.key(pkgName), annotations, function (err) {
+    if (err) console.error(err.message)
+  })
+  this.client.expire(this.key(pkgName), this.ttl, function (err) {
+    if (err) console.error(err.message)
+    return cb()
+  })
+}
+
+ClientManager.prototype.sign = function (payload, client) {
+  var secret = client.tokens[0].access_token
+  return 'sha256=' + hash(payload, secret)
+}
+
+ClientManager.prototype.key = function (pkgName) {
+  return this.redisPrefix + pkgName
+}
+
+function hash (payload, secret) {
+  return crypto.createHmac('sha256', secret)
+    .update(payload)
+    .digest('hex')
 }
 
 module.exports = ClientManager

--- a/lib/client-manager.js
+++ b/lib/client-manager.js
@@ -1,0 +1,5 @@
+function ClientManager (opts) {
+
+}
+
+module.exports = ClientManager

--- a/lib/start.js
+++ b/lib/start.js
@@ -18,6 +18,11 @@ exports.builder = function (yargs) {
       describe: 'url of oauth micro-service to pull clients from',
       default: 'http://127.0.0.1:8084'
     })
+    .option('redis-url', {
+      alias: 'r',
+      descirbe: 'url of redis server to store annotations in',
+      default: 'redis://0.0.0.0:6379'
+    })
 }
 
 exports.handler = function (argv) {

--- a/package.json
+++ b/package.json
@@ -30,13 +30,15 @@
     "mocha": "^2.4.5",
     "nock": "^8.0.0",
     "nyc": "^6.4.0",
-    "request": "^2.70.0",
     "standard": "^6.0.8",
     "standard-version": "^2.1.2"
   },
   "dependencies": {
+    "async": "^1.5.2",
+    "lodash": "^4.10.0",
     "redis": "^2.5.3",
+    "request": "^2.70.0",
     "restify": "^4.0.4",
-    "yargs": "^4.6.0-candidate"
+    "yargs": "^4.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "standard",
-    "test": "nyc mocha test.js",
+    "test": "nyc mocha",
     "version": "standard-version",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
@@ -35,6 +35,7 @@
     "standard-version": "^2.1.2"
   },
   "dependencies": {
+    "redis": "^2.5.3",
     "restify": "^4.0.4",
     "yargs": "^4.6.0-candidate"
   }

--- a/test/client-manager.js
+++ b/test/client-manager.js
@@ -1,20 +1,72 @@
 /* global describe, it, beforeEach */
 
+var ClientManager = require('../lib/client-manager')
 var client = require('redis').createClient()
-client.unref()
+var crypto = require('crypto')
+var expect = require('chai').expect
+var fs = require('fs')
+var nock = require('nock')
 
 require('chai').should()
+
 global.console.info = function () {}
 
 describe('ClientManager', function () {
-  beforeEach(function () {
-    client.flushdb()
+  describe('load', function () {
+    it('loads a list of clients from the OAuth 2.0 micro-service', function (done) {
+      var clients = nock('http://0.0.0.0:8084')
+        .get('/client')
+        .reply(200, fs.readFileSync('./test/fixtures/clients.json', 'utf-8'))
+      var clientManager = new ClientManager()
+      clientManager.load(function (err) {
+        expect(err).to.equal(undefined)
+        clientManager.clients.length.should.equal(2)
+        clients.done()
+        return done()
+      })
+    })
   })
 
-  it('loads a list of clients from the OAuth 2.0 microservice', function (done) {
-    client.set('foo', 'bar')
-    client.get('foo', function (_err, res) {
-      return done()
+  describe('sign', function () {
+    var clients = JSON.parse(fs.readFileSync('./test/fixtures/clients.json', 'utf-8'))
+
+    it('returns an appropriate signature given a payload and client', function () {
+      var clientManager = new ClientManager()
+      var signature = clientManager.sign('{"json": "awesome"}', clients[0])
+      var expected = 'sha256=' + crypto.createHmac('sha256', '0f5aab83-7a62-4129-b407-e4837b52c111')
+        .update('{"json": "awesome"}')
+        .digest('hex')
+      signature.should.equal(expected)
+    })
+  })
+
+  describe('annotationForPageLoad', function () {
+    var annotation1 = {
+      id: 'abc-123-abc',
+      status: 'green',
+      'status-message': 'module scanned',
+      description: 'my awesome integration',
+      'external-link': 'http://example.com/foo-package/audit',
+      'external-link-text': 'view details'
+    }
+    var annotations = [
+      annotation1
+    ]
+
+    beforeEach(function () {
+      client.flushdb()
+    })
+
+    it('returns annotation from redis if it exists in the database', function (done) {
+      var clientManager = new ClientManager()
+      clientManager.cacheAnnotations('foo-pkg', annotations, function () {
+        clientManager.annotationsForPageLoad('foo-pkg', function (annotations) {
+          var annotation = annotations[0]
+          annotation.id.should.equal('abc-123-abc')
+          annotation.fingerprint.should.match(/[a-z0-9]{64}/)
+          return done()
+        })
+      })
     })
   })
 })

--- a/test/client-manager.js
+++ b/test/client-manager.js
@@ -17,6 +17,7 @@ describe('ClientManager', function () {
       var clients = nock('http://0.0.0.0:8084')
         .get('/client')
         .reply(200, fs.readFileSync('./test/fixtures/clients.json', 'utf-8'))
+
       var clientManager = new ClientManager()
       clientManager.load(function (err) {
         expect(err).to.equal(undefined)
@@ -41,7 +42,7 @@ describe('ClientManager', function () {
   })
 
   describe('annotationForPageLoad', function () {
-    var annotation1 = {
+    var annotation = {
       id: 'abc-123-abc',
       status: 'green',
       'status-message': 'module scanned',
@@ -49,21 +50,66 @@ describe('ClientManager', function () {
       'external-link': 'http://example.com/foo-package/audit',
       'external-link-text': 'view details'
     }
-    var annotations = [
-      annotation1
-    ]
+    var clients = JSON.parse(fs.readFileSync('./test/fixtures/clients.json', 'utf-8'))
 
     beforeEach(function () {
+      delete annotation.fingerprint
       client.flushdb()
     })
 
-    it('returns annotation from redis if it exists in the database', function (done) {
+    it('returns annotation from cache it is populated', function (done) {
       var clientManager = new ClientManager()
-      clientManager.cacheAnnotations('foo-pkg', annotations, function () {
-        clientManager.annotationsForPageLoad('foo-pkg', function (annotations) {
+      var pkgName = 'foo-pkg'
+
+      clientManager.cacheAnnotations(pkgName, [annotation], function () {
+        clientManager.annotationsForPageLoad(pkgName, function (annotations) {
           var annotation = annotations[0]
           annotation.id.should.equal('abc-123-abc')
           annotation.fingerprint.should.match(/[a-z0-9]{64}/)
+          return done()
+        })
+      })
+    })
+
+    it('requests annotations from an external API if cache is not populated', function (done) {
+      var pkgName = 'foo-pkg'
+      var payload = JSON.stringify({
+        event: 'package:page-load',
+        package: pkgName,
+        sender: {
+          email: clients[0].tokens[0].user_email
+        }
+      })
+      var clientManager = new ClientManager()
+      var signature = clientManager.sign(payload, clients[0])
+      var getClients = nock('http://0.0.0.0:8084')
+        .get('/client')
+        .reply(200, [clients[0]])
+      // mock requesting a payload from an external
+      // service. the webhook endpoint is stored on
+      // the OAuth client.
+      var getAnnotation = nock('http://www.example.com', {
+        reqheaders: {
+          'npm-signature': signature,
+          'content-type': 'application/json'
+        }
+      })
+        .post('/fetch/data', payload)
+        .reply(200, annotation)
+
+      clientManager.load(function (err) {
+        expect(err).to.equal(undefined)
+        clientManager.annotationsForPageLoad(pkgName, function (annotations) {
+          expect(err).to.equal(undefined)
+
+          var annotation = annotations[0]
+          // the client-id gets written to the
+          // annotation as a unique identifier.
+          annotation.id.should.equal(clients[0].client_id)
+          annotation.fingerprint.should.match(/[a-z0-9]{64}/)
+
+          getClients.done()
+          getAnnotation.done()
           return done()
         })
       })

--- a/test/client-manager.js
+++ b/test/client-manager.js
@@ -1,0 +1,20 @@
+/* global describe, it, beforeEach */
+
+var client = require('redis').createClient()
+client.unref()
+
+require('chai').should()
+global.console.info = function () {}
+
+describe('ClientManager', function () {
+  beforeEach(function () {
+    client.flushdb()
+  })
+
+  it('loads a list of clients from the OAuth 2.0 microservice', function (done) {
+    client.set('foo', 'bar')
+    client.get('foo', function (_err, res) {
+      return done()
+    })
+  })
+})

--- a/test/fixtures/clients.json
+++ b/test/fixtures/clients.json
@@ -1,0 +1,66 @@
+[
+  {
+    "id": 2,
+    "client_id": "37ddb29e-b7c1-43b3-8235-7b966971d350",
+    "client_secret": "f35fbd2e-36d3-4e36-beb6-6f58c604cd4d",
+    "email": null,
+    "name": "foo security",
+    "homepage": null,
+    "description": null,
+    "callback": "http://www.example.com/fetch/data",
+    "created": "2016-04-12T07:12:15.151Z",
+    "deleted": null,
+    "tokens": [
+      {
+        "id": 2,
+        "client_id": 2,
+        "access_token": "0f5aab83-7a62-4129-b407-e4837b52c111",
+        "refresh_token": "5a5b96ae-3c2e-4428-8098-3577fa773ff0",
+        "user_email": "another@email.com",
+        "refresh_expires": "2026-04-12T00:12:15.161Z",
+        "access_expires": "2026-04-12T00:12:15.161Z",
+        "created": "2016-04-12T07:12:15.161Z",
+        "deleted": null,
+        "_client": null
+      },
+      {
+        "id": 3,
+        "client_id": 2,
+        "access_token": "056353ac-8bf0-462b-9eb4-9f4b4ec8fcbb",
+        "refresh_token": "9ca4ffb7-d500-4c05-90b0-c94fef530067",
+        "user_email": "third@email.com",
+        "refresh_expires": "2026-04-12T00:12:15.161Z",
+        "access_expires": "2026-04-12T00:12:15.161Z",
+        "created": "2016-04-12T07:12:15.161Z",
+        "deleted": null,
+        "_client": null
+      }
+    ]
+  },
+  {
+    "id": 3,
+    "client_id": "62ac2117-3a83-41a2-9b8e-9a2cab72bdbd",
+    "client_secret": "94e33ca1-fa8b-476d-a183-0ae99f2d3760",
+    "email": null,
+    "name": "bar security",
+    "homepage": null,
+    "description": null,
+    "callback": "htp://api2.example.com/data/2",
+    "created": "2016-04-12T07:12:15.160Z",
+    "deleted": null,
+    "tokens": [
+      {
+        "id": 4,
+        "client_id": 3,
+        "access_token": "fba2a9b6-1ac8-4c81-891d-e6501e866e3b",
+        "refresh_token": "5392d4fa-59e2-44a9-9415-f7814b2e886e",
+        "user_email": "some@email.com",
+        "refresh_expires": "2026-04-12T00:12:15.169Z",
+        "access_expires": "2026-04-12T00:12:15.169Z",
+        "created": "2016-04-12T07:12:15.169Z",
+        "deleted": null,
+        "_client": null
+      }
+    ]
+  }
+]

--- a/test/server.js
+++ b/test/server.js
@@ -1,7 +1,7 @@
 /* global describe, it, before, after */
 
 var server = null
-var annotationApi = require('./')
+var annotationApi = require('../')
 var request = require('request')
 
 require('chai').should()


### PR DESCRIPTION
For V1, the annotations API makes an HTTP request out to an external integrator and asks for annotations that should placed on the package page. This annotation information will then be rendered on the package page as a widget.

As an example, we might talk to a security integration, like Lift, and ask whether there are any known security vulnerabilities on the `yargs` module.

In this pull request we, I introduce logic that:

* allows annotations to be fetched for a given package name.
  * it first checks if there are annotations in cache for this package, and returns them from cache.
  * if it misses cache, it queries the external services and places the response in cache.

see also: https://github.com/npm/annotation-poller which will consume from this API.

reviewers: @nexdrew, @soldair 