### PR TITLE
feat: add route for fetching annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.2.0"></a>
+# [1.2.0](https://github.com/npm/annotation-api/compare/v1.1.0...v1.2.0) (2016-04-19)
+
+
+### Features
+
+* add route for fetching annotations ([2c96d3f](https://github.com/npm/annotation-api/commit/2c96d3f))
+
+
+
 <a name="1.1.0"></a>
 # [1.1.0](https://github.com/npm/annotation-api/compare/v1.0.0...v1.1.0) (2016-04-19)
 

--- a/index.js
+++ b/index.js
@@ -26,8 +26,7 @@ module.exports = function (opts, cb) {
     console.info(server.name + ' listening at ' + server.url)
   })
 
-  clientManager.load(function (err) {
-    if (err) console.error(err.message)
-    else console.info('loaded addon clients')
+  clientManager.start(function () {
+    console.info('loaded addon clients')
   })
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 var restify = require('restify')
+var ClientManager = require('./lib/client-manager')
 
 module.exports = function (opts, cb) {
   var server = restify.createServer({ name: 'annotation-api' })
+  var clientManager = new ClientManager(opts)
 
   server.use(restify.bodyParser())
   server.use(restify.queryParser())
@@ -11,9 +13,21 @@ module.exports = function (opts, cb) {
     return next()
   })
 
+  server.get('/api/v1/annotations/:pkg', function (req, res, next) {
+    clientManager.annotationsForPageLoad(req.params.pkg, function (annotations) {
+      res.send(annotations)
+      return next()
+    })
+  })
+
   // start listening on port.
   server.listen(opts.port, opts.host, function () {
     cb(null, server)
     console.info(server.name + ' listening at ' + server.url)
+  })
+
+  clientManager.load(function (err) {
+    if (err) console.error(err.message)
+    else console.info('loaded addon clients')
   })
 }

--- a/lib/client-manager.js
+++ b/lib/client-manager.js
@@ -10,6 +10,8 @@ function ClientManager (opts) {
     oauthUrl: 'http://0.0.0.0:8084/client',
     redisUrl: 'redis://0.0.0.0:6379',
     redisPrefix: '__anotation_api_',
+    loadFrequency: 8000,
+    loadInterval: null,
     // only make requests to external sites every 15 seconds.
     ttl: 15
   }, opts)
@@ -32,10 +34,38 @@ ClientManager.prototype.load = function (loaded) {
     if (err) {
       return loaded(err)
     } else {
-      _this.clients.push.apply(_this.clients, body)
+      // add any new clients that we observe,
+      // don't add the same client twice.
+      var idLookup = _.keyBy(_this.clients, 'client_id')
+      _this.clients.push.apply(_this.clients, body.filter(function (c) {
+        return !idLookup[c.client_id]
+      }))
       return loaded()
     }
   })
+}
+
+// reload clients on an interval, this solves
+// two problems:
+// 1. handles annotation-api booting before oauth service.
+// 2. handles new clients being added.
+ClientManager.prototype.start = function (cb) {
+  var _this = this
+  this.loadInterval = setInterval(function () {
+    _this.load(function (err) {
+      if (err) console.error(err.message)
+      // invoke the cb provided the
+      // first time that we load clients.
+      if (cb) {
+        cb()
+        cb = null
+      }
+    })
+  }, this.loadFrequency)
+}
+
+ClientManager.prototype.stop = function () {
+  if (this.loadInterval) clearInterval(this.loadInterval)
 }
 
 // fetch annotations from external services, returning

--- a/lib/client-manager.js
+++ b/lib/client-manager.js
@@ -26,7 +26,7 @@ ClientManager.prototype.load = function (loaded) {
     url: this.oauthUrl,
     json: true
   }, function (err, res, body) {
-    if (res.statusCode !== 200) {
+    if (res && res.statusCode !== 200) {
       err = Error('unexpected status code = ' + res.statusCode)
     }
     if (err) {
@@ -91,11 +91,19 @@ ClientManager.prototype.fetchAnnotations = function (pkgName, cb) {
       }
       if (err) console.error(err.message)
       if (body) {
-        body = JSON.parse(body)
-        // the integration id is used to de-dupe.
-        // the UI on the frontend.
-        body.id = client.client_id
+        try {
+          body = JSON.parse(body)
+        } catch (err) {
+          console.error(err.message)
+          body = {}
+        }
       }
+
+      // the integration id is used to de-dupe.
+      // the UI on the frontend.
+      body = body || {}
+      body.id = client.client_id
+
       return done(null, body)
     })
   }, function (_err, annotations) {

--- a/lib/start.js
+++ b/lib/start.js
@@ -9,14 +9,14 @@ exports.builder = function (yargs) {
       describe: 'port to listen on'
     })
     .option('host', {
-      alias: 'o',
+      alias: 't',
       default: '0.0.0.0',
       describe: 'host to bind to'
     })
     .option('oauth-url', {
       alias: 'o',
       describe: 'url of oauth micro-service to pull clients from',
-      default: 'http://127.0.0.1:8084'
+      default: 'http://0.0.0.0:8084/client'
     })
     .option('redis-url', {
       alias: 'r',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npm/annotation-api",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "API for polling a set of external integrations and annotating packages and other entities on npmjs.com",
   "main": "index.js",
   "scripts": {

--- a/test/client-manager.js
+++ b/test/client-manager.js
@@ -100,8 +100,6 @@ describe('ClientManager', function () {
       clientManager.load(function (err) {
         expect(err).to.equal(undefined)
         clientManager.annotationsForPageLoad(pkgName, function (annotations) {
-          expect(err).to.equal(undefined)
-
           var annotation = annotations[0]
           // the client-id gets written to the
           // annotation as a unique identifier.

--- a/test/server.js
+++ b/test/server.js
@@ -6,6 +6,7 @@ var request = require('request')
 
 require('chai').should()
 global.console.info = function () {}
+global.console.error = function () {}
 
 describe('annotation-api', function () {
   before(function (done) {


### PR DESCRIPTION
adds route for grabbing package annotations (`/api/v1/annotations/:pkg`), fixed a couple minor nits in the process found while performing end-to-end testing:

* my "integration" was returning a string rather than an Object, I made it so we handle this edge-case.
* we were attempting to use `res` even though it was not defined if a connection could not be negotiated with the OAuth API.