### PR TITLE
fix: tweaks to better handle slow upstream services

### DIFF
--- a/lib/client-manager.js
+++ b/lib/client-manager.js
@@ -13,7 +13,9 @@ function ClientManager (opts) {
     loadFrequency: 8000,
     loadInterval: null,
     // only make requests to external sites every 15 seconds.
-    ttl: 15
+    ttl: 15,
+    // how long should we cache if request to upstream server failed?
+    ttlFailure: 2
   }, opts)
 
   this.client = redis.createClient(this.redisUrl)
@@ -114,6 +116,7 @@ ClientManager.prototype.fetchAnnotations = function (pkgName, cb) {
     request.post({
       url: client.webhook,
       body: payload,
+      timeout: 5000, // only wait 5s max for upstream response.
       headers: {
         'content-type': 'application/json',
         'npm-signature': signature
@@ -123,6 +126,8 @@ ClientManager.prototype.fetchAnnotations = function (pkgName, cb) {
         err = Error('unexpected status code = ' + res.statusCode)
       }
       if (err) console.error(err.message)
+      // return a blank annotation on errors.
+      if (err) return done(null, null)
       if (body) {
         try {
           body = JSON.parse(body)
@@ -169,6 +174,7 @@ Reminder that annotations look something like this:
 }]
 */
 ClientManager.prototype.cacheAnnotations = function (pkgName, annotations, cb) {
+  var failures = this.clients.length !== annotations.length
   if (!annotations.length) return cb()
   // toss a fingerprint on our annotation so that the
   // frontend can dedupe and turn it into a string for Redis.
@@ -179,7 +185,7 @@ ClientManager.prototype.cacheAnnotations = function (pkgName, annotations, cb) {
   this.client.lpush(this.key(pkgName), annotations, function (err) {
     if (err) console.error(err.message)
   })
-  this.client.expire(this.key(pkgName), this.ttl, function (err) {
+  this.client.expire(this.key(pkgName), failures ? this.ttlFailure : this.ttl, function (err) {
     if (err) console.error(err.message)
     return cb()
   })


### PR DESCRIPTION
* if any upstream services fail to respond, we will now only wait `3s` before requesting from the upstream service again.
* we no longer attempt to parse JSON on non 200 response.
* we now limit the request timeout to an upstream service to `5s`.