### PR TITLE
fix: cache related performance tweaks

### DIFF
--- a/lib/client-manager.js
+++ b/lib/client-manager.js
@@ -187,8 +187,8 @@ ClientManager.prototype.cacheAnnotations = function (pkgName, annotations, cb) {
     annotation.fingerprint = hash(JSON.stringify(annotation), '')
     return JSON.stringify(annotation)
   })
-  this.client.del(this.key(pkgName))
   this.client.setex('lock_' + this.key(pkgName), failures ? this.ttlFailure : this.ttl, true)
+  this.client.del(this.key(pkgName))
   this.client.lpush(this.key(pkgName), annotations, function (err) {
     if (err) console.error(err.message)
     return cb()

--- a/lib/client-manager.js
+++ b/lib/client-manager.js
@@ -79,19 +79,29 @@ ClientManager.prototype.stop = function () {
 // }
 ClientManager.prototype.annotationsForPageLoad = function (pkgName, cb) {
   var _this = this
-  this.client.lrange(this.key(pkgName), 0, 9999, function (err, annotations) {
+  _this.client.get('lock_' + this.key(pkgName), function (err, lock) {
+    var repopulateCache = !lock
+
     if (err) console.error(err.message)
-    if (annotations && annotations.length) {
-      return cb(annotations.map(function (annotation) {
+    _this.client.lrange(_this.key(pkgName), 0, 9999, function (err, annotations) {
+      if (err) console.error(err.message)
+      annotations = annotations || []
+
+      // we always return from cache, but repopulate
+      // it periodically.
+      cb(annotations.map(function (annotation) {
         return JSON.parse(annotation)
       }))
-    } else {
-      _this.fetchAnnotations(pkgName, function (annotations) {
-        _this.cacheAnnotations(pkgName, annotations, function () {
-          return cb(annotations)
+
+      // populate the cache in the background.
+      if (repopulateCache) {
+        _this.fetchAnnotations(pkgName, function (annotations) {
+          _this.cacheAnnotations(pkgName, annotations, function () {
+            console.info('populated new annotations for', pkgName)
+          })
         })
-      })
-    }
+      }
+    })
   })
 }
 
@@ -177,10 +187,9 @@ ClientManager.prototype.cacheAnnotations = function (pkgName, annotations, cb) {
     annotation.fingerprint = hash(JSON.stringify(annotation), '')
     return JSON.stringify(annotation)
   })
+  this.client.del(this.key(pkgName))
+  this.client.setex('lock_' + this.key(pkgName), failures ? this.ttlFailure : this.ttl, true)
   this.client.lpush(this.key(pkgName), annotations, function (err) {
-    if (err) console.error(err.message)
-  })
-  this.client.expire(this.key(pkgName), failures ? this.ttlFailure : this.ttl, function (err) {
     if (err) console.error(err.message)
     return cb()
   })


### PR DESCRIPTION
* since we know the front-end `annotation-poller` will be requesting content every few seconds, we now return immediately and populate the cache in the background.
* we no longer expire the content in our cache (since this data will change rarely) instead we update it in the background if it has changed upstream.