### PR TITLE
feat: add endpoint to support scoped packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,11 +13,19 @@ module.exports = function (opts, cb) {
     return next()
   })
 
-  server.get('/api/v1/annotations/:pkg', function (req, res, next) {
-    clientManager.annotationsForPageLoad(req.params.pkg, function (annotations) {
+  function packageHandler (req, res, next, pkgName) {
+    clientManager.annotationsForPageLoad(pkgName, function (annotations) {
       res.send(annotations)
       return next()
     })
+  }
+
+  server.get('/api/v1/annotations/:pkg', function (req, res, next) {
+    packageHandler(req, res, next, req.params.pkg)
+  })
+
+  server.get('/api/v1/annotations/:scope/:pkg', function (req, res, next) {
+    packageHandler(req, res, next, req.params.scope + '/' + req.params.pkg)
   })
 
   // start listening on port.

--- a/test/server.js
+++ b/test/server.js
@@ -28,6 +28,28 @@ describe('annotation-api', function () {
     })
   })
 
+  it('supports unscoped package', function (done) {
+    request.get({
+      url: 'http://0.0.0.0:9999/api/v1/annotations/lodash',
+      json: true
+    }, function (req, res, body) {
+      res.statusCode.should.equal(200)
+      body.should.be.an('array').and.be.empty
+      return done()
+    })
+  })
+
+  it('supports scoped package', function (done) {
+    request.get({
+      url: 'http://0.0.0.0:9999/api/v1/annotations/@angular/core',
+      json: true
+    }, function (req, res, body) {
+      res.statusCode.should.equal(200)
+      body.should.be.an('array').and.be.empty
+      return done()
+    })
+  })
+
   after(function (done) {
     server.close(function () {
       return done()


### PR DESCRIPTION
Currently, attempting to fetch annotations for a scoped package at e.g. `http://localhost:8085/api/v1/annotations/@scope/pkg` returns a 404 because the extra slash does not match the package route `/api/v1/annotations/:pkg`.

Add a new route `/api/v1/annotations/:scope/:pkg` to support `@scope/pkg` URLs, using same logic as existing route.

Also add unit tests to verify a 200 is returned for each route.

cc @bcoe 